### PR TITLE
Added auto-run script, fixed companion computer script, forgot to checkout...

### DIFF
--- a/PX4_to_XBee.py
+++ b/PX4_to_XBee.py
@@ -28,7 +28,7 @@ SERIAL_BUFFER_MAX = 0xFFF
 ARBITRARY_MIN = 100
 XBEE_MAX_BAUD = 230400
 PX4_DEFAULT_BAUD = 115200
-
+GCS_64BIT_ADDR = '0013a20040d68c2e'
 
 ########################################################################################################################
 #
@@ -50,8 +50,9 @@ def obtain_network(xbee: XBeeDevice):
 
 		# Check devices on the network by Node ID
 		for device in network.get_devices():
-			print('XBee device found with Node ID: {}'.format(device.get_node_id()))
-			if device.get_node_id() == 'GCS':
+			address = device.get_64bit_addr().address.hex()
+			print(f'XBee device found with 64bit address: {address}')
+			if address == GCS_64BIT_ADDR:
 				return device, network
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ cp 66-xbee.rules /etc/udev/rules.d/66-xbee.rules
 cp 67-pixhawk.rules /etc/udev/rules.d/67-pixhawk.rules
 udevadm control --reload && udevadm trigger
 ```
-(TODO)
 
 [QGroundControl](https://github.com/mavlink/qgroundcontrol) has been the GCS software of choice 
 throughout 

--- a/pixhawk2xbee
+++ b/pixhawk2xbee
@@ -1,0 +1,4 @@
+#!/usr/bin/bash
+
+sleep 10
+python3.7 %PATH_TO_DIRECTOR%/Telemetry-via-DigiMesh/PX4_to_XBee.py

--- a/pixhawk2xbee.service
+++ b/pixhawk2xbee.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Pixhawk to XBee script.
+
+[Service]
+ExecStart=/usr/local/bin/pixhawk2xbee
+
+[Install]
+WantedBy=multi-user.target 


### PR DESCRIPTION
Companion computer script PX4_to_XBee.py now searches for a specified 64bit address in string format, as node_id appears to be None when there is a large amount of data queued up on an XBee.